### PR TITLE
"vcd_vapp" Module Release 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
+providers.tf
 
 # Crash log files
 crash.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Virtual Application Terraform Module
 
-This Terraform module will deploy Virtual Applications (vApps) into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provsion new vApps into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
+This Terraform module will deploy Virtual Applications (vApps) into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provision new vApps into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
 
 ## Requirements
 
@@ -38,7 +38,7 @@ This is an example of a `main.tf` file that uses the `"github.com/global-vmware/
 
 ```terraform
 module "vcd_vapp" {
-  source                = "github.com/global-vmware/vcd_vapp.git?ref=v1.2.0"
+  source                = "github.com/global-vmware/vcd_vapp.git?ref=v1.2.1"
   
   vdc_org_name          = "<US1-VDC-ORG-NAME>"
   vdc_group_name        = "<US1-VDC-GRP-NAME>"

--- a/main.tf
+++ b/main.tf
@@ -10,13 +10,14 @@ terraform {
 }
 
 data "vcd_vdc_group" "vdc_group" {
-  name = var.vdc_group_name
+  org       = var.vdc_org_name
+  name      = var.vdc_group_name
 }
 
 resource "vcd_vapp" "vapp" {
-  for_each = { for name in var.vapp_names: name => {} }
-  name     = each.key
-  org      = var.vdc_org_name
-  vdc      = var.vdc_name
-  power_on = var.power_on
+  for_each  = { for name in var.vapp_names: name => {} }
+  org       = var.vdc_org_name
+  name      = each.key
+  vdc       = var.vdc_name
+  power_on  = var.power_on
 }


### PR DESCRIPTION
- "vcd_vapp" Module Release 1.2.1

- Added the "org" Argument to the "vcd_vdc_group" Data Source

- Updated the source URL Reference in the "vcd_vapp" Module Code Snippet to Version 1.2.1 in the Example Usage Section of the README